### PR TITLE
Cli Flags, #15

### DIFF
--- a/xml-comp.go
+++ b/xml-comp.go
@@ -54,8 +54,8 @@ To get current version, usage: xml-comp -v`,
 	} else {
 		if os.Args[1] == "-fd" {
 			//proceeding with action for folder comparer
-			pathA := os.Args[1]
-			pathB := os.Args[2]
+			pathA := os.Args[2]
+			pathB := os.Args[3]
 			fmt.Println("Creating instance ...")
 			instance := comparer.Data{PathA: pathA, PathB: pathB}
 			fmt.Println("Output:-")

--- a/xml-comp.go
+++ b/xml-comp.go
@@ -12,19 +12,37 @@ const (
 )
 
 func main() {
+	//map for options
+	options := map[string]string{
+		//help
+		"help": `
+To Use Folder Verification, usage: xml-comp -fd pathA pathB
+You need two paths that we call pathA & pathB, which are described bellow:
+	pathA: /home/user/folder1
+	pathB: /home/user/folder2
+
+To get current version, usage: xml-comp -v`,
+		"-h": `Yo
+To Use Folder Verification, usage: xml-comp -fd pathA pathB
+u need two paths that we call pathA & pathB, which are described bellow:
+	pathA: /home/user/folder1
+	pathB: /home/user/folder2
+
+To get current version, usage: xml-comp -v`,
+		//version
+		"version": "Current version is " + Version,
+		"-v":      "Current version is " + Version,
+		//Folder and File function index
+		"-fd": "folder",
+		"-fl": "file",
+	}
 	//Help option
 	if len(os.Args) == 1 { // xml-comp
 		fmt.Println("Kindly mention options")
 		fmt.Println("Eg: xml-comp help")
-	} else if len(os.Args) == 2 {
-		//Help output
-		if os.Args[1] == "help" {
-			fmt.Println("You need two paths that we call pathA & pathB, which are described bellow:")
-			fmt.Println("	pathA: /home/user/folder1")
-			fmt.Println("	pathB: /home/user/folder2")
-			fmt.Println("Use: xml-comp pathA pathB")
-		}
-	} else { //xml-comp pathA pathB
+	} else {
+		//Flags
+
 		pathA := os.Args[1]
 		pathB := os.Args[2]
 		fmt.Println("Creating instance ...")

--- a/xml-comp.go
+++ b/xml-comp.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ArxdSilva/XML-Comp/comparer"
+	"XML-Comp/comparer"
 )
 
 const (
@@ -22,7 +22,7 @@ You need two paths that we call pathA & pathB, which are described bellow:
 	pathB: /home/user/folder2
 
 To get current version, usage: xml-comp -v`,
-		"-h": `Yo
+		"-h": `
 To Use Folder Verification, usage: xml-comp -fd pathA pathB
 u need two paths that we call pathA & pathB, which are described bellow:
 	pathA: /home/user/folder1
@@ -33,21 +33,35 @@ To get current version, usage: xml-comp -v`,
 		"version": "Current version is " + Version,
 		"-v":      "Current version is " + Version,
 		//Folder and File function index
-		"-fd": "folder",
-		"-fl": "file",
+		"-fd": "Mention paths for comparing, usage: xml-comp -fd pathA pathB",
+		"-fl": "Coming soon!",
 	}
 	//Help option
 	if len(os.Args) == 1 { // xml-comp
 		fmt.Println("Kindly mention options")
 		fmt.Println("Eg: xml-comp help")
-	} else {
+	} else if len(os.Args) == 2 {
 		//Flags
-
-		pathA := os.Args[1]
-		pathB := os.Args[2]
-		fmt.Println("Creating instance ...")
-		instance := comparer.Data{PathA: pathA, PathB: pathB}
-		fmt.Println("Output:-")
-		fmt.Println(instance.CompareContainingFoldersAndFiles())
+		val := os.Args[1]
+		//Existence of flags
+		if len(options[val]) > 0 {
+			//Flag exists
+			fmt.Println(options[val])
+		} else {
+			//Doesn't exist
+			fmt.Println("Seems like you chose wrong option, see $ xml-comp help")
+		}
+	} else {
+		if os.Args[1] == "-fd" {
+			//proceeding with action for folder comparer
+			pathA := os.Args[1]
+			pathB := os.Args[2]
+			fmt.Println("Creating instance ...")
+			instance := comparer.Data{PathA: pathA, PathB: pathB}
+			fmt.Println("Output:-")
+			fmt.Println(instance.CompareContainingFoldersAndFiles())
+		} else {
+			fmt.Println(options[os.Args[1]])
+		}
 	}
 }


### PR DESCRIPTION
Fixes #15 
Usage as mentioned in issue #15, 
`$ xml-comp -h` or `$ xml-comp help` for help
`$ xml-comp -v` or `$ xml-comp version` for version
`$ xml-comp -fd pathA pathB` for folder compare
`$ xml-comp -fl pathA pathB` for file compare
**Note** Installation same as CLI Pull Request.
